### PR TITLE
Implement "maxSize" to compliment "minSize"

### DIFF
--- a/core-splitter.html
+++ b/core-splitter.html
@@ -43,7 +43,7 @@ Example:
 
 <link rel="import" href="../polymer/polymer.html">
 
-<polymer-element name="core-splitter" attributes="direction locked minSize allowOverflow"
+<polymer-element name="core-splitter" attributes="direction locked minSize maxSize allowOverflow"
     on-trackstart="{{trackStart}}" on-track="{{track}}" on-down="{{preventSelection}}">
 
 <template>
@@ -74,6 +74,15 @@ Example:
      */
     minSize: '',
 
+    /**
+     * Maximum width to which the splitter target can be sized
+     *
+     * @attribute maxSize
+     * @type number
+     * @default -1 (infinite)
+     */
+    maxSize: -1,
+      
     /**
      * Locks the split bar so it can't be dragged.
      *
@@ -122,7 +131,9 @@ Example:
         old.style[old.__splitterMinSize] = '';
       }
       var min = this.target.__splitterMinSize = this.horizontal ? 'minHeight' : 'minWidth';
+      var max = this.target.__splitterMaxSize = this.horizontal ? 'maxHeight' : 'maxWidth';
       this.target.style[min] = this.minSize;
+      this.target.style[max] = this.maxSize + 'px';
     },
 
     trackStart: function() {


### PR DESCRIPTION
I simply duplicated all the code for minSize.  The only difference is that the default value for maxSize is -1, as 0 would mean you could never move the splitter.
